### PR TITLE
Consolidating mgh<->ctx conversion functions

### DIFF
--- a/ctxmgh/QD_ctx_load_mgh.m
+++ b/ctxmgh/QD_ctx_load_mgh.m
@@ -13,4 +13,4 @@ function vol_ctx = QD_ctx_load_mgh(fname);
 
 
 [vol, M] = QD_load_mgh(fname);
-vol_ctx = QD_mgh2ctx(vol,M);
+vol_ctx = mgh2ctx(vol,M);

--- a/ctxmgh/QD_ctx_save_mgh.m
+++ b/ctxmgh/QD_ctx_save_mgh.m
@@ -10,5 +10,5 @@ function QD_ctx_save_mgh(vol_ctx,fname)
 % created 1/7/2011 by N White
 
 
-[vol M] = QD_ctx2mgh(vol_ctx);
+[vol M] = ctx2mgh(vol_ctx);
 QD_save_mgh(vol,fname,M);

--- a/ctxmgh/QD_load_mgh.m
+++ b/ctxmgh/QD_load_mgh.m
@@ -1,5 +1,5 @@
 function [vol, M, mr_parms, volsz] = QD_load_mgh(fname,slices,frames,headeronly,keepsingle)
-% [vol, M, mr_parms, volsz] = fs_load_mgh(fname,[slices],[frames],[headeronly],[keepsingle])
+% [vol, M, mr_parms, volsz] = QD_load_mgh(fname,[slices],[frames],[headeronly],[keepsingle])
 %
 % Required Input:
 %   fname: path of the mgh file

--- a/ctxmgh/mgh2ctx.m
+++ b/ctxmgh/mgh2ctx.m
@@ -1,46 +1,25 @@
-function vol_ctx = mgh2ctx(vol,M)
-% function vol_ctx = QD_mgh2ctx(vol,M)
-% 
-% QD_mgh2ctx.m - takes 1-based array of voxel intensities and 1-based M_vox2_ras matrix
-%                and produces ctx 1-based volume structure
-%
-% Input:
-%   vol: nd-array of 1-based voxel intensities.
-%        Note, only first volume is used for geometry information
-%     M: 1-based M_vox2ras matrix
-%
-% last mod: 1/7/2011 by N White
+function vols_ctx = mgh2ctx(vols, M)
 
-[width,height,depth] = size(vol) ;
+if ~exist('M','var'), M = eye(4); end
 
-xsize = norm(M(:,1));
-ysize = norm(M(:,2));
-zsize = norm(M(:,3));
-x_r = M(1,1)/xsize;
-x_a = M(2,1)/xsize;
-x_s = M(3,1)/xsize;
-y_r = M(1,2)/ysize;
-y_a = M(2,2)/ysize;
-y_s = M(3,2)/ysize;
-z_r = M(1,3)/zsize;
-z_a = M(2,3)/zsize;
-z_s = M(3,3)/zsize;
-ci = (width)/2 ; cj = (height)/2 ; ck = (depth)/2 ;
-c_r = M(1,4) + (M(1,1)*ci + M(1,2)*cj + M(1,3)*ck) ;
-c_a = M(2,4) + (M(2,1)*ci + M(2,2)*cj + M(2,3)*ck);
-c_s = M(3,4) + (M(3,1)*ci + M(3,2)*cj + M(3,3)*ck);
+dims = size(vols);
+width = dims(1); height=dims(2); depth=dims(3); nvol=prod(dims(4:end)); 
 
-vol_ctx.imgs = double(vol);
-vol_ctx.Mvxl2lph = M_RAS_TO_LPH * M;
-vol_ctx.dimc = size(vol,2);
-vol_ctx.dimr = size(vol,1);
-vol_ctx.dimd = size(vol,3);
-vol_ctx.vx = xsize;
-vol_ctx.vy = ysize;
-vol_ctx.vz = zsize;
-vol_ctx.lphcent=[-c_r;-c_a;c_s]; % 1-based
-vol_ctx.DirCol=[-x_r;-x_a;x_s];
-vol_ctx.DirRow=[-y_r;-y_a;y_s];
-vol_ctx.DirDep=[-z_r;-z_a;z_s];
+[xsize,ysize,zsize,x_r,x_a,x_s,y_r,y_a,y_s,z_r,z_a,z_s,c_r,c_a,c_s] = mat2mgh(M,width,height,depth);
 
-% save ctx using ultimately fs_save_mgh it assumes Mvxl2lph is 1-based
+vols_ctx = struct;
+vols_ctx.imgs = double(vols);
+vols_ctx.Mvxl2lph = M_RAS_TO_LPH * M;
+vols_ctx.dimc = height; % size(vol,2);
+vols_ctx.dimr = width; % size(vol,1);
+vols_ctx.dimd = depth; % size(vol,3);
+vols_ctx.vx = xsize;
+vols_ctx.vy = ysize;
+vols_ctx.vz = zsize;
+vols_ctx.lphcent=[-c_r;-c_a;c_s];
+vols_ctx.DirCol=[-x_r;-x_a;x_s];
+vols_ctx.DirRow=[-y_r;-y_a;y_s];
+vols_ctx.DirDep=[-z_r;-z_a;z_s];
+
+end
+

--- a/dicom/QD_read_dicomdir.m
+++ b/dicom/QD_read_dicomdir.m
@@ -15,6 +15,6 @@ nfiles = length(fnames);
 
 [vol, M, dcminfo] = QD_read_dicomvol(fnames);
 
-ctx = ctx_mgh2ctx(vol, M);
+ctx = mgh2ctx(vol, M);
 
 end

--- a/dicom/ctx_read_dicomfiles.m
+++ b/dicom/ctx_read_dicomfiles.m
@@ -1,4 +1,4 @@
 function ctx_vol = ctx_read_dicomfiles(dcminfo)
 
 [vol,M] = Convert_Dicom_Images(dcminfo);
-ctx_vol = ctx_mgh2ctx(vol,M);
+ctx_vol = mgh2ctx(vol,M);


### PR DESCRIPTION
@ofrei @parekhpravesh @dpecheva 

I noticed that there are multiple versions of functions for converting between mgh and ctx, for example:
mgh2ctx
QD_mgh2ctx
ctx_mgh2ctx

I put the latest modifications that I could find on my end into the version without the prefix (mgh2ctx), and propose that we transition towards exclusive use of that version. At some point I'd like to delete the others with the QD_ and ctx_ prefixes, so that there's only one function to maintain.
